### PR TITLE
Create assertions for non-strict comparison.

### DIFF
--- a/circuits/common/verify-hydra-commitment.circom
+++ b/circuits/common/verify-hydra-commitment.circom
@@ -14,7 +14,7 @@ template VerifyHydraCommitment() {
   signal input commitmentMapperPubKey[2];
   signal input commitmentReceipt[3];
 
-  // Verify that the user have the right commitment secret
+  // Verify that the user has the right commitment secret
   // This is a Proof Of Commitment Ownership
   component commitment = Poseidon(1);
   commitment.inputs[0] <== secret;

--- a/circuits/common/verify-merkle-path.circom
+++ b/circuits/common/verify-merkle-path.circom
@@ -18,7 +18,7 @@ template PositionSwitcher() {
 }
 
 
-// Verifies that merkle path is correct for given merkle root and a leaf
+// Verifies that merkle path is correct for a given merkle root and leaf
 // pathIndices input is an array of 0/1 selectors telling whether given 
 // pathElement is on the left or right side of merkle path
 template VerifyMerklePath(levels) {

--- a/circuits/hydra-s1.circom
+++ b/circuits/hydra-s1.circom
@@ -98,12 +98,10 @@ template hydraS1(registryTreeHeight, accountsTreeHeight) {
 
   // Verify claimed value validity
   // Prevent overflow of comparator range
-  component sourceInRange = compconstant(2**252);
+  component sourceInRange = Is252Bits();
   sourceInRange.in <== sourceValue;
-  sourceInRange.out === 1;
-  component claimedInRange = compconstant(2**252);
+  component claimedInRange = Is252Bits();
   claimedInRange.in <== claimedValue;
-  claimedInRange.out === 1;
   // 0 <= claimedValue <= sourceValue
   component leq = LessEqThan(252);
   leq.in[0] <== claimedValue;
@@ -132,6 +130,21 @@ template hydraS1(registryTreeHeight, accountsTreeHeight) {
   // Square serve to avoid removing by the compilator optimizer
   signal chainIdSquare;
   chainIdSquare <== chainId * chainId;
+}
+
+// Verifies that a number is less than 2^252
+template Is252Bits() {
+  signal input in;
+
+  component bits = Num2Bits(254);
+  bits.in <== in;
+
+  component compare = CompConstant(2**252);
+  for (var i=0; i<254; i++) {
+    compare.in[i] <== bits.out[i];
+  }
+
+  compare.out === 0;
 }
 
 component main {public [commitmentMapperPubKey, registryTreeRoot, ticketIdentifier, userTicket, destinationIdentifier, claimedValue, chainId, accountsTreeValue, isStrict]} = hydraS1(20,20);

--- a/circuits/hydra-s1.circom
+++ b/circuits/hydra-s1.circom
@@ -98,9 +98,9 @@ template hydraS1(registryTreeHeight, accountsTreeHeight) {
 
   // Verify claimed value validity
   // Prevent overflow of comparator range
-  component sourceInRange = Is252Bits();
+  component sourceInRange = Num2Bits(252);
   sourceInRange.in <== sourceValue;
-  component claimedInRange = Is252Bits();
+  component claimedInRange = Num2Bits(252);
   claimedInRange.in <== claimedValue;
   // 0 <= claimedValue <= sourceValue
   component leq = LessEqThan(252);
@@ -130,21 +130,6 @@ template hydraS1(registryTreeHeight, accountsTreeHeight) {
   // Square serve to avoid removing by the compilator optimizer
   signal chainIdSquare;
   chainIdSquare <== chainId * chainId;
-}
-
-// Verifies that a number is less than 2^252
-template Is252Bits() {
-  signal input in;
-
-  component bits = Num2Bits(254);
-  bits.in <== in;
-
-  component compare = CompConstant(2**252);
-  for (var i=0; i<254; i++) {
-    compare.in[i] <== bits.out[i];
-  }
-
-  compare.out === 0;
 }
 
 component main {public [commitmentMapperPubKey, registryTreeRoot, ticketIdentifier, userTicket, destinationIdentifier, claimedValue, chainId, accountsTreeValue, isStrict]} = hydraS1(20,20);

--- a/circuits/hydra-s1.circom
+++ b/circuits/hydra-s1.circom
@@ -1,9 +1,11 @@
 pragma circom 2.0.0;
 
+include "../node_modules/circomlib/circuits/comparators.circom";
 include "../node_modules/circomlib/circuits/poseidon.circom";
 include "../node_modules/circomlib/circuits/bitify.circom";
 include "../node_modules/circomlib/circuits/mux1.circom";
 include "../node_modules/circomlib/circuits/babyjub.circom";
+
 include "./common/verify-merkle-path.circom";
 include "./common/verify-hydra-commitment.circom";
 
@@ -94,13 +96,14 @@ template hydraS1(registryTreeHeight, accountsTreeHeight) {
   }
 
   // Verify claimed value validity
+  // 0 <= claimedValue <= sourceValue
+  component leq = LessEqThan(252);
+  leq.in[0] <== claimedValue;
+  leq.in[1] <== sourceValue;
+  leq.out === 1;
   // If isStrict == 1 then claimedValue == sourceValue
-  // If isStrict == 0 then 0 <= claimedValue <= sourceValue
-  assert(claimedValue<=sourceValue);
   0 === (isStrict-1)*isStrict;
-  component iszero = IsZero();
-  iszero.in <== isStrict;
-  sourceValue === claimedValue+((sourceValue-claimedValue)*iszero.out);
+  sourceValue === sourceValue+((claimedValue-sourceValue)*isStrict);
 
   // Verify the userTicket is valid
   // compute the sourceSecretHash using the hash of the sourceSecret

--- a/circuits/hydra-s1.circom
+++ b/circuits/hydra-s1.circom
@@ -1,5 +1,6 @@
 pragma circom 2.0.0;
 
+include "../node_modules/circomlib/circuits/compconstant.circom";
 include "../node_modules/circomlib/circuits/comparators.circom";
 include "../node_modules/circomlib/circuits/poseidon.circom";
 include "../node_modules/circomlib/circuits/bitify.circom";
@@ -96,6 +97,13 @@ template hydraS1(registryTreeHeight, accountsTreeHeight) {
   }
 
   // Verify claimed value validity
+  // Prevent overflow of comparator range
+  component sourceInRange = compconstant(2**252);
+  sourceInRange.in <== sourceValue;
+  sourceInRange.out === 1;
+  component claimedInRange = compconstant(2**252);
+  claimedInRange.in <== claimedValue;
+  claimedInRange.out === 1;
   // 0 <= claimedValue <= sourceValue
   component leq = LessEqThan(252);
   leq.in[0] <== claimedValue;

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     ]
   },
   "dependencies": {
-    "@sismo-core/commitment-mapper-tester-js": "^1.0.10"
+    "@sismo-core/commitment-mapper-tester-js": "^1.0.10",
+    "@sismo-core/kv-merkle-tree": "^1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     ]
   },
   "dependencies": {
-    "@sismo-core/commitment-mapper-tester-js": "^1.0.10",
-    "@sismo-core/kv-merkle-tree": "^1.0.4"
+    "@sismo-core/commitment-mapper-tester-js": "^1.0.10"
   }
 }


### PR DESCRIPTION
`assert(claimedValue<=sourceValue);` does not produce a constraint, it just stops witness generation. So an adversarial prover could remove the assert line and generate an invalid proof that the verifier would accept. `assert` can't produce constraints because [all constraints in circom are quadratic](https://docs.circom.io/circom-language/constraint-generation/#:~:text=Only%20quadratic%20expressions%20are%20allowed%20to%20be%20included%20in%20constraints), and `<=` is not quadratic.

Note that `LessThan(n)` can fail for values greater than `2^n` due to overflow, hence that `compconstant` components.